### PR TITLE
Add Consolas to code font list for Windows

### DIFF
--- a/assets/css/typo.css
+++ b/assets/css/typo.css
@@ -168,7 +168,7 @@ mark {
 
 /* 代码片断 */
 pre, code, pre tt {
-  font-family: Courier, 'Courier New', monospace;
+  font-family: Consolas, Courier, 'Courier New', monospace;
 }
 
 pre {


### PR DESCRIPTION
Windows自带的Consolas比Courier New要好看些。